### PR TITLE
fix(api): return questions_count per day so mobile app can show pendi…

### DIFF
--- a/app/Http/Controllers/Api/ReadingController.php
+++ b/app/Http/Controllers/Api/ReadingController.php
@@ -32,6 +32,7 @@ class ReadingController extends Controller
         $userId = $request->user()->id;
 
         $days = Day::where('date_assigned', '<=', today())
+            ->withCount('questions')
             ->withCount(['questions as answered_count' => function ($query) use ($userId) {
                 $query->whereExists(function ($sub) use ($userId) {
                     $sub->from('responses')

--- a/app/Http/Resources/DayResource.php
+++ b/app/Http/Resources/DayResource.php
@@ -15,6 +15,7 @@ class DayResource extends JsonResource
             'chapters'      => $this->chapters,
             'day_month'     => $this->day_month,
             'questions'     => QuestionResource::collection($this->whenLoaded('questions')),
+            'questions_count' => $this->when(isset($this->questions_count), $this->questions_count),
             'answered_count' => $this->when(isset($this->answered_count), $this->answered_count),
         ];
     }


### PR DESCRIPTION
…ng badge

Without withCount('questions'), the list endpoint only returned answered_count. The mobile app then calculated totalQuestions = 0 and showed no pending badge for unanswered days (Completado still appeared because answered_count > 0 drives that branch independently).